### PR TITLE
QSP-16 Option Exchange Liquidity Addition Misses Some ERC20 Calls

### DIFF
--- a/contracts/exchanges/OptionExchange.sol
+++ b/contracts/exchanges/OptionExchange.sol
@@ -150,6 +150,14 @@ contract OptionExchange {
         // Approving Option transfer to Exchange
         option.approve(address(exchange), optionAmount);
 
+        require(
+            IERC20(token).transferFrom(msg.sender, address(this), amountToken),
+            "Could not transfer tokens from caller"
+        );
+
+        // Approving Token transfer to pool
+        IERC20(token).approve(address(exchange), amountToken);
+
         exchange.addLiquidity(optionAddress, token, optionAmount, amountToken, deadline, msg.sender, params);
 
         emit OptionsStaked(msg.sender, optionAddress, optionAmount, token, amountToken);


### PR DESCRIPTION
Severity: Low Risk
File(s) affected: `contracts/exchanges/OptionExchange.sol`

Description: When adding liquidity by means of calling `OptionExchange.addLiquiditytransferFrom(msg.sender, ...)`, the token address is not used in a `transferFrom(msg.sender, ...)` call; also, `tokenAmount` is not approved to be spent by the exchange.

Recommendation: Add the required ERC20 function calls.