### PR TITLE
QSP-17 AMM Provider Liquidity Addition Misses Some ERC20 Calls

### DIFF
--- a/contracts/exchanges/AMMProvider.sol
+++ b/contracts/exchanges/AMMProvider.sol
@@ -109,6 +109,12 @@ contract AMMProvider is ExchangeProvider {
             "Could not transfer tokens from caller"
         );
 
+        // Approving Option transfer to pool
+        ERC20(tokenA).approve(address(pool), amountA);
+
+        // Approving Token transfer to pool
+        ERC20(tokenB).approve(address(pool), amountB);
+
         pool.addLiquidity(amountB, amountA, recipient);
     }
 


### PR DESCRIPTION
Severity: Low Risk

File(s) affected: `contracts/exchanges/AMMProvider.sol`

Description: In `AMMProvider.addLiquidity` the A and B tokens amounts are not approved to be spent by the pool; consequently, all calls to that function will throw.

Recommendation: Add the required ERC20 function calls.