### PR TITLE
QSP-24 Unlocked Pragma

### DIFF
--- a/contracts/amm/AMM.sol
+++ b/contracts/amm/AMM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/amm/BlackScholes.sol
+++ b/contracts/amm/BlackScholes.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // solhint-disable var-name-mixedcase
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "../interfaces/INormalDistribution.sol";
 

--- a/contracts/amm/FeePool.sol
+++ b/contracts/amm/FeePool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/contracts/amm/NormalDistribution.sol
+++ b/contracts/amm/NormalDistribution.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "../interfaces/INormalDistribution.sol";
 

--- a/contracts/amm/OptionAMMFactory.sol
+++ b/contracts/amm/OptionAMMFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "../interfaces/IOptionAMMFactory.sol";
 import "./OptionAMMPool.sol";

--- a/contracts/amm/OptionAMMPool.sol
+++ b/contracts/amm/OptionAMMPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "./AMM.sol";

--- a/contracts/amm/Sigma.sol
+++ b/contracts/amm/Sigma.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/exchange/OptionExchange.sol
+++ b/contracts/exchange/OptionExchange.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/interfaces/BPool.sol
+++ b/contracts/interfaces/BPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface BPool {
     function swapExactAmountIn(

--- a/contracts/interfaces/IBFactory.sol
+++ b/contracts/interfaces/IBFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IBFactory {
     function newBPool() external returns (address);

--- a/contracts/interfaces/IBlackScholes.sol
+++ b/contracts/interfaces/IBlackScholes.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 // TODO: add other methods
 interface IBlackScholes {

--- a/contracts/interfaces/IChainlinkPriceFeed.sol
+++ b/contracts/interfaces/IChainlinkPriceFeed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IChainlinkPriceFeed {
     function decimals() external view returns (uint8);

--- a/contracts/interfaces/IERC20Mintable.sol
+++ b/contracts/interfaces/IERC20Mintable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IERC20Mintable {
     function mint(uint256 amount) external returns (bool);

--- a/contracts/interfaces/IFeePool.sol
+++ b/contracts/interfaces/IFeePool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IFeePool {
     function feeValue() external view returns (uint256);

--- a/contracts/interfaces/INormalDistribution.sol
+++ b/contracts/interfaces/INormalDistribution.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface INormalDistribution {
     function getProbability(int256 z, uint256 decimals) external view returns (int256);

--- a/contracts/interfaces/IOptionAMMFactory.sol
+++ b/contracts/interfaces/IOptionAMMFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IOptionAMMFactory {
     function createPool(

--- a/contracts/interfaces/IOptionAMMPool.sol
+++ b/contracts/interfaces/IOptionAMMPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IOptionAMMPool {
     function addLiquidity(

--- a/contracts/interfaces/IOptionBuilder.sol
+++ b/contracts/interfaces/IOptionBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "../options/PodOption.sol";
 

--- a/contracts/interfaces/IOptionFactory.sol
+++ b/contracts/interfaces/IOptionFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./IPodPut.sol";
 

--- a/contracts/interfaces/IPodOption.sol
+++ b/contracts/interfaces/IPodOption.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IPodOption {
     function underlyingAsset() external view returns (address);

--- a/contracts/interfaces/IPodPut.sol
+++ b/contracts/interfaces/IPodPut.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IPodPut {
     function mint(uint256, address) external;

--- a/contracts/interfaces/IPriceFeed.sol
+++ b/contracts/interfaces/IPriceFeed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IPriceFeed {
     function getLatestPrice() external view returns (int256);

--- a/contracts/interfaces/IPriceProvider.sol
+++ b/contracts/interfaces/IPriceProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 // TODO: add other methods
 

--- a/contracts/interfaces/ISigma.sol
+++ b/contracts/interfaces/ISigma.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 // TODO: add call other methods
 interface ISigma {

--- a/contracts/interfaces/IUniswapV1.sol
+++ b/contracts/interfaces/IUniswapV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IUniswapFactory {
     function createExchange(address token) external returns (address exchange);

--- a/contracts/interfaces/IWETH.sol
+++ b/contracts/interfaces/IWETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 interface IWETH {
     function deposit() external payable;

--- a/contracts/lib/ExponentLib.sol
+++ b/contracts/lib/ExponentLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: APACHE 2.0
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./FixidityLib.sol";
 import "./LogarithmLib.sol";

--- a/contracts/lib/FixidityLib.sol
+++ b/contracts/lib/FixidityLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: APACHE 2.0
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 /**
  * @title FixidityLib

--- a/contracts/lib/LogarithmLib.sol
+++ b/contracts/lib/LogarithmLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: APACHE 2.0
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./FixidityLib.sol";
 

--- a/contracts/lib/RequiredDecimals.sol
+++ b/contracts/lib/RequiredDecimals.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/mocks/MockAMM.sol
+++ b/contracts/mocks/MockAMM.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../amm/AMM.sol";

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/faucet.sol
+++ b/contracts/mocks/faucet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "../interfaces/IERC20Mintable.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/contracts/mocks/tokens/MintableERC20.sol
+++ b/contracts/mocks/tokens/MintableERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/tokens/MintableInterestBearing.sol
+++ b/contracts/mocks/tokens/MintableInterestBearing.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/mocks/tokens/WBTC.sol
+++ b/contracts/mocks/tokens/WBTC.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./MintableERC20.sol";
 

--- a/contracts/mocks/tokens/WETH.sol
+++ b/contracts/mocks/tokens/WETH.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 import "@openzeppelin/contracts/utils/Address.sol";
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 contract WETH {
     string public name = "Wrapped Ether";

--- a/contracts/options/OptionFactory.sol
+++ b/contracts/options/OptionFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "../interfaces/IOptionBuilder.sol";
 import "./PodOption.sol";

--- a/contracts/options/PodCall.sol
+++ b/contracts/options/PodCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./PodOption.sol";
 

--- a/contracts/options/PodCallBuilder.sol
+++ b/contracts/options/PodCallBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./PodCall.sol";
 import "./PodOption.sol";

--- a/contracts/options/PodOption.sol
+++ b/contracts/options/PodOption.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/options/PodPut.sol
+++ b/contracts/options/PodPut.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./PodOption.sol";
 

--- a/contracts/options/PodPutBuilder.sol
+++ b/contracts/options/PodPutBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./PodPut.sol";
 import "./PodOption.sol";

--- a/contracts/options/WPodCall.sol
+++ b/contracts/options/WPodCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./PodCall.sol";
 import "../interfaces/IWETH.sol";

--- a/contracts/options/WPodCallBuilder..sol
+++ b/contracts/options/WPodCallBuilder..sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./WPodCall.sol";
 

--- a/contracts/options/WPodPut.sol
+++ b/contracts/options/WPodPut.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./PodPut.sol";
 import "../interfaces/IWETH.sol";

--- a/contracts/options/WPodPutBuilder.sol
+++ b/contracts/options/WPodPutBuilder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "./WPodPut.sol";
 

--- a/contracts/oracle/ChainlinkPriceFeed.sol
+++ b/contracts/oracle/ChainlinkPriceFeed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "../interfaces/IPriceFeed.sol";
 import "../interfaces/IChainlinkPriceFeed.sol";

--- a/contracts/oracle/PriceProvider.sol
+++ b/contracts/oracle/PriceProvider.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.8;
+pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "../interfaces/IPriceFeed.sol";


### PR DESCRIPTION
**Severity**: `Informational` 
**Status**: `Unresolved`
**File(s) affected**: `contracts/*`
**Description**: Every Solidity file specifies in the header a version number of the format pragma solidity (^)0.4.*. The caret (^) before the version number implies an unlocked pragma, meaning that the compiler will use the specified version and above, hence the term "unlocked".
**Recommendation**: For consistency and to prevent unexpected behavior in the future, it is recommended to remove the caret to lock the file onto a specific Solidity version.