### PR TITLE
SOD-11

### DIFF
--- a/contracts/amm/BlackScholes.sol
+++ b/contracts/amm/BlackScholes.sol
@@ -133,7 +133,7 @@ contract BlackScholes is IBlackScholes {
         int256 iv2 = iv.mul(iv);
 
         int256 A = spotPrice.div(strikePrice).ln();
-        int256 B = (iv2 / 2 + riskFree).mul(time);
+        int256 B = (iv2.div(2e18) + riskFree).mul(time);
 
         int256 n = A + B;
         int256 d = iv.mul(time.sqrt());

--- a/contracts/amm/NormalDistribution.sol
+++ b/contracts/amm/NormalDistribution.sol
@@ -432,7 +432,7 @@ contract NormalDistribution is INormalDistribution, Ownable {
         require(decimals >= 5 && decimals < 77, "NormalDistribution: invalid decimals");
         uint256 absZ = _abs(z);
         uint256 truncatedZ = absZ.div(10**(decimals.sub(2))).mul(100);
-        uint256 fourthDigit = _abs(z).div(10**(decimals.sub(3))) - _abs(z).div(10**(decimals.sub(2))).mul(10);
+        uint256 fourthDigit = absZ.div(10**(decimals.sub(3))) - absZ.div(10**(decimals.sub(2))).mul(10);
         uint256 responseDecimals = 10**(decimals.sub(5));
         uint256 responseValue;
 


### PR DESCRIPTION
`BlackScholes.sol`: Function `_getZScores()` does not use `PRBMathSD59x18` consistently