### PR TITLE
SOD-5

### DIFF
--- a/abi/FeePool.json
+++ b/abi/FeePool.json
@@ -290,7 +290,7 @@
       },
       {
         "internalType": "uint8",
-        "name": "decimals",
+        "name": "feeDecimals",
         "type": "uint8"
       }
     ],

--- a/contracts/amm/FeePool.sol
+++ b/contracts/amm/FeePool.sol
@@ -49,11 +49,12 @@ contract FeePool is IFeePool, Ownable {
      * @notice Sets fee and the decimals
      *
      * @param feeBaseValue Fee value
-     * @param decimals Fee decimals
+     * @param feeDecimals Fee decimals
      */
-    function setFee(uint256 feeBaseValue, uint8 decimals) external override onlyOwner {
+    function setFee(uint256 feeBaseValue, uint8 feeDecimals) external override onlyOwner {
+        require(feeDecimals <= 77 && feeBaseValue <= uint256(10)**feeDecimals, "FeePool: Invalid Fee data");
         _feeBaseValue = feeBaseValue;
-        _feeDecimals = decimals;
+        _feeDecimals = feeDecimals;
         emit FeeUpdated(_token, _feeBaseValue, _feeDecimals);
     }
 

--- a/test/amm/FeePool.test.js
+++ b/test/amm/FeePool.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const { ethers } = require('hardhat')
 const { toBigNumber } = require('../../utils/utils')
 
-describe.only('FeePool', () => {
+describe('FeePool', () => {
   let FeePool, pool
   let usdc
   let owner0, owner1, feePayer, poolOwner

--- a/test/amm/FeePool.test.js
+++ b/test/amm/FeePool.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai')
 const { ethers } = require('hardhat')
 const { toBigNumber } = require('../../utils/utils')
 
-describe('FeePool', () => {
+describe.only('FeePool', () => {
   let FeePool, pool
   let usdc
   let owner0, owner1, feePayer, poolOwner
@@ -61,9 +61,14 @@ describe('FeePool', () => {
         .to.emit(pool, 'FeeUpdated')
         .withArgs(usdc.address, newBaseFeeValue, newFeeDecimals)
 
-      const feeValue = await pool.feeValue()
       expect(await pool.feeValue()).to.equal(newBaseFeeValue)
       expect(await pool.feeDecimals()).to.equal(newFeeDecimals)
+    })
+
+    it('cannot charge more than 100% base fees', async () => {
+      const decimals = await usdc.decimals()
+      const tx = pool.setFee(10 ** decimals + 1, decimals)
+      await expect(tx).to.be.revertedWith('FeePool: Invalid Fee data')
     })
   })
 


### PR DESCRIPTION
`FeePool.sol`: Validation mismatch between function `setFee()` and the contract’s constructor